### PR TITLE
Added support for feed items' images and for YouTube Thumbnails

### DIFF
--- a/add.go
+++ b/add.go
@@ -37,6 +37,8 @@ func addFeed(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	parseYoutubeFeeds(feed)
+
 	// parsing the regex
 	reg, err := regexp.Compile(addRequest.Filter)
 	if err != nil {
@@ -73,9 +75,10 @@ func addFeed(writer http.ResponseWriter, request *http.Request) {
 	// fetching and filtering initial elements
 	filteredItems := make([]*gofeed.Item, 0, len(feed.Items))
 
-	for _, itm := range feed.Items {
+	for index, itm := range feed.Items {
+
 		if reg.MatchString(itm.Title) {
-			filteredItems = append(filteredItems, itm)
+			filteredItems = append(filteredItems, feed.Items[index])
 		}
 	}
 

--- a/db.go
+++ b/db.go
@@ -67,6 +67,10 @@ func addItems(feedID int64, items []*gofeed.Item, markAsSent bool) {
 			Feed:        feedID,
 		}
 
+		if feedelement.Image != nil {
+			element.ImageURL = feedelement.Image.URL
+		}
+
 		err := db.Where(entities.RssItem{URL: element.URL}).FirstOrCreate(&element).Error
 		if err != nil {
 			log.Printf("there was an error adding %s, %v", element.Title, err)

--- a/entities/entities.go
+++ b/entities/entities.go
@@ -17,6 +17,7 @@ type RssItem struct {
 	URL         string         `json:"URL" gorm:"not null,unique"`
 	Sent        bool           `json:"-"`
 	Feed        int64          `json:"-" gorm:"not null"`
+	ImageURL    string         `json:"-"`
 }
 
 // RssFeed represents a rss feed

--- a/fetch.go
+++ b/fetch.go
@@ -30,6 +30,8 @@ func fetchElements() {
 				continue
 			}
 
+			parseYoutubeFeeds(feed)
+
 			// filtering elements
 			reg := regexp.MustCompile(f.Filter)
 

--- a/notify.go
+++ b/notify.go
@@ -19,7 +19,7 @@ func notificationRoutine() {
 
 			_, err = bot.Send(message)
 			if err != nil {
-				log.Printf("Send to Telegram failed due to: %v", err)
+				log.Printf("Send \"%s\" to Telegram failed due to: %v", message.Text, err)
 				continue
 			}
 

--- a/utility.go
+++ b/utility.go
@@ -52,7 +52,7 @@ func createTelegramMessage(element entities.RssItem) tg.MessageConfig {
 
 	// Creating the message with pre-parsed items
 	if element.ImageURL != "" {
-		text = fmt.Sprintf("📣 *%s*\n\n[🖼️](%s)\n\n➡️ %s", feedTitle, element.ImageURL, element.Title)
+		text = fmt.Sprintf("📣 *%s*\n\n[➡️](%s) %s", feedTitle, element.ImageURL, element.Title)
 	} else {
 		text = fmt.Sprintf("📣 *%s*\n\n➡️ %s", feedTitle, element.Title)
 	}

--- a/utility.go
+++ b/utility.go
@@ -34,11 +34,27 @@ func createTelegramKeyboard(URL string) tg.InlineKeyboardMarkup {
 func createTelegramMessage(element entities.RssItem) tg.MessageConfig {
 
 	feedTitle := retrieveFeedTitle(element.Feed)
-	tgMarkdownReservedChars := []string{".", "-", "(", ")", "#", "!", "|"}
 
-	text := fmt.Sprintf("*%s*\n\n%s", feedTitle, element.Title)
+	if feedTitle == "" {
+		feedTitle = "New Feed!"
+	}
+
+	tgMarkdownReservedChars := []string{".", "-", "(", ")", "#", "!", "|", "[", "]", "_", "*", "`", "~"}
+
+	var text string
+
+	// Pre-parsing our elements for markdown Reserved Chars
 	for _, char := range tgMarkdownReservedChars {
-		text = strings.ReplaceAll(text, char, fmt.Sprintf(`\%s`, char))
+		element.Title = strings.ReplaceAll(element.Title, char, fmt.Sprintf(`\%s`, char))
+		element.ImageURL = strings.ReplaceAll(element.ImageURL, char, fmt.Sprintf(`\%s`, char))
+		feedTitle = strings.ReplaceAll(feedTitle, char, fmt.Sprintf(`\%s`, char))
+	}
+
+	// Creating the message with pre-parsed items
+	if element.ImageURL != "" {
+		text = fmt.Sprintf("📣 *%s*\n\n[🖼️](%s)\n\n➡️ %s", feedTitle, element.ImageURL, element.Title)
+	} else {
+		text = fmt.Sprintf("📣 *%s*\n\n➡️ %s", feedTitle, element.Title)
 	}
 
 	message := tg.NewMessage(telegramChatID, text)

--- a/youtube.go
+++ b/youtube.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/mmcdole/gofeed"
+)
+
+func parseYoutubeFeeds(feed *gofeed.Feed) {
+
+	parsedUrl, err := url.Parse(feed.Link)
+	if err != nil {
+		log.Printf("Error parsing URL due to: %v", err)
+		return
+	}
+
+	// I trim the prefix www. because I don't know if youtube will use always the www. CNAME
+	if strings.TrimPrefix(parsedUrl.Hostname(), "www.") != "youtube.com" {
+		return
+	}
+
+	for index := range feed.Items {
+		addThumbnailToYoutubeItems(feed.Items[index])
+	}
+}
+
+func addThumbnailToYoutubeItems(item *gofeed.Item) {
+
+	// If I already have an image, I don't add it
+	if item.Image != nil && item.Image.URL != "" {
+		return
+	}
+
+	var url string
+
+	// Checking if there are Extensions since it's there that I have the thumbnail
+	if item.Extensions == nil {
+		return
+	}
+
+	// Checking media -> group, then since I have multiple []Extensions I use for and map access to retrieve (finally) the thumbnail
+	media, ok := item.Extensions["media"]
+	if !ok {
+		return
+	}
+
+	group, ok := media["group"]
+	if !ok {
+		return
+	}
+
+	for _, groupElem := range group {
+		if groupElem.Name != "group" {
+			continue
+		}
+
+		if groupElem.Children == nil {
+			continue
+		}
+
+		thumbnail, ok := groupElem.Children["thumbnail"]
+		if !ok {
+			continue
+		}
+
+		for _, thumbElem := range thumbnail {
+			if thumbElem.Name != "thumbnail" {
+				continue
+			}
+
+			if thumbElem.Attrs == nil {
+				continue
+			}
+
+			url = thumbElem.Attrs["url"]
+		}
+	}
+
+	// When finally I have an URL, I add the Image directly into the feed
+
+	item.Image = &gofeed.Image{
+		URL:   url,
+		Title: "thumbnail",
+	}
+
+}


### PR DESCRIPTION
Closes #5 

Now the bot saves on DB and sends via Telegram the Image of the feed RSS.

Since I use this bot for YouTube, I also added some functions in order to retrieve the thumbnail when the hostname is "youtube.com". 

These functions don't impact other feeds since, in the end, they just add a gofeed.Image pointer to items from Youtube.

I also enhanced the markdown support changing the order in which the message is parsed. Now the parsing is before the creation of the message itself, in order to not lose any markdown tag we want to use.